### PR TITLE
Fixed incorrect incremental coverage reports and moved them to a separate subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,10 +118,13 @@ if(GCOVR)
       set(GCOV_EXE "llvm-cov gcov")
     endif()
     if(${USE_COVERAGE_ANALYSIS} STREQUAL "ON")
-      add_custom_target(coverage gcovr  --gcov-executable "${GCOV_EXE}" -su -r .. -e ../test -e googletest-src)
+      add_custom_target(
+        coverage gcovr  --gcov-executable "${GCOV_EXE}" -su -r .. -e ../test -e googletest-src)
     elseif(${USE_COVERAGE_ANALYSIS} STREQUAL "HTML")
-      add_custom_target(coverage gcovr --gcov-executable "${GCOV_EXE}" --html-details -su -r .. -e ../test -e googletest-src -o coverage.html
-                        COMMENT "Generating coverage report into coverage.html...")
+      add_custom_target(
+        coverage ${CMAKE_COMMAND} -E make_directory coverage
+        COMMAND gcovr --gcov-executable "${GCOV_EXE}" --html-details -su -r .. -e ../test -e googletest-src -o coverage/coverage.html
+        COMMENT "Generating coverage report into coverage/coverage.html...")
     endif()
   endif()
 elseif(USE_COVERAGE_ANALYSIS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,11 +119,11 @@ if(GCOVR)
     endif()
     if(${USE_COVERAGE_ANALYSIS} STREQUAL "ON")
       add_custom_target(
-        coverage gcovr  --gcov-executable "${GCOV_EXE}" -su -r .. -e ../test -e googletest-src)
+        coverage gcovr --gcov-executable "${GCOV_EXE}" --delete -su -r .. -e ../test -e googletest-src) 
     elseif(${USE_COVERAGE_ANALYSIS} STREQUAL "HTML")
       add_custom_target(
         coverage ${CMAKE_COMMAND} -E make_directory coverage
-        COMMAND gcovr --gcov-executable "${GCOV_EXE}" --html-details -su -r .. -e ../test -e googletest-src -o coverage/coverage.html
+        COMMAND gcovr --gcov-executable "${GCOV_EXE}" --delete --html-details -su -r .. -e ../test -e googletest-src -o coverage/coverage.html 
         COMMENT "Generating coverage report into coverage/coverage.html...")
     endif()
   endif()


### PR DESCRIPTION
The incremental coverage reports should be fixed by `--delete`-ing the .gcda files in gcovr after processing.

Also, @Hossam-Abdin mentioned that coverage reports shouldn't litter the build_debug folder, so I've created a separate one for them in the coverage CMake target.