### PR TITLE
Refactor fixed-size heaps into SteadyHeap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(SOURCES AdaptiveSpinLock.cpp ChannelBase.cpp ChannelImpl.cpp Scheduler.cpp S
 set(BBTEST_SOURCES PacketTest.cpp PolledChannelTest.cpp SchedulerTest.cpp TimerTest.cpp ScheduledChannelTest.cpp)
 
 # Put those tests here which really, desperately need the implementation
-set(WBTEST_SOURCES AdaptiveSpinLockTest.cpp ThreadIdTest.cpp)
+set(WBTEST_SOURCES AdaptiveSpinLockTest.cpp ThreadIdTest.cpp SteadyHeapTest.cpp)
 
 
 # General settings

--- a/src/ChannelImpl.cpp
+++ b/src/ChannelImpl.cpp
@@ -129,7 +129,7 @@ int ChannelImpl::GetQueuedBufferLength() {
   return queued_packets_.size();
 }
 
-bool ChannelImpl::PacketOrdering::operator()(PacketBase* a, PacketBase* b) {
+bool ChannelImpl::PacketOrdering::operator()(const PacketBase* a, const PacketBase* b) {
   return a->timestamp() > b->timestamp();
 }
 

--- a/src/ChannelImpl.cpp
+++ b/src/ChannelImpl.cpp
@@ -14,6 +14,7 @@ ChannelImpl::ChannelImpl(const char* name, int capacity, int packet_size,
                          SchedulerImpl* scheduler)
     : single_thread_object_(single_thread_object),
       callback_(callback),
+      queued_packets_(PacketOrdering()),
       name_(name),
       capacity_(capacity),
       packet_size_(packet_size),
@@ -65,9 +66,7 @@ void ChannelImpl::Push(PacketBase* packet) {
   std::lock_guard<AdaptiveSpinLock> lock(GetQueuedMutex());
   assert((int)queued_packets_.size() < capacity_);
   Timer::Time earliest = queued_packets_.empty() ? Timer::kMaxTime : PeekNext();
-  queued_packets_.push_back(packet);
-  std::push_heap(queued_packets_.begin(), queued_packets_.end(),
-                 PacketOrdering());
+  queued_packets_.push_heap(packet);
   if (IsScheduled() && PeekNext() < earliest) {
     if (earliest == Timer::kMaxTime)
       scheduler_->JobsArrived(this);
@@ -103,9 +102,7 @@ PacketBase* ChannelImpl::PopNext() {
   assert((int)queued_packets_.size() <= capacity_);
   assert(!queued_packets_.empty());
   PacketBase* earliest = queued_packets_.front();
-  std::pop_heap(queued_packets_.begin(), queued_packets_.end(),
-                PacketOrdering());
-  queued_packets_.pop_back();
+  queued_packets_.pop_heap();
   if (IsScheduled()) {
     if (queued_packets_.empty())
       scheduler_->JobsDropped(this);

--- a/src/ChannelImpl.h
+++ b/src/ChannelImpl.h
@@ -2,8 +2,10 @@
 #define _CHANNELIMPL_H_
 
 #include <cstdint>
+#include <functional>
 #include <vector>
 #include "AdaptiveSpinLock.h"
+#include "SteadyHeap.h"
 #include "pipert/ChannelBase.h"
 
 namespace pipert {
@@ -145,7 +147,7 @@ class ChannelImpl {
 
   /// Job (to-be-processed packets) queue.
   /// This is a heap having the oldest timestamp on top.
-  std::vector<PacketBase*> queued_packets_;
+  SteadyHeap<PacketBase*, std::function<bool(PacketBase*, PacketBase*)>> queued_packets_;
 
   const char* name_;          ///< See GetName().
   int capacity_;              ///< See GetCapacity().

--- a/src/ChannelImpl.h
+++ b/src/ChannelImpl.h
@@ -107,7 +107,7 @@ class ChannelImpl {
  private:
   /// Ordering between packets based on timestamp.
   struct PacketOrdering {
-    bool operator()(PacketBase* a, PacketBase* b);
+    bool operator()(const PacketBase* a, const PacketBase* b);
   };
 
   /// \return True if this Channel is a scheduled one, false if polled.
@@ -147,7 +147,9 @@ class ChannelImpl {
 
   /// Job (to-be-processed packets) queue.
   /// This is a heap having the oldest timestamp on top.
-  SteadyHeap<PacketBase*, std::function<bool(PacketBase*, PacketBase*)>> queued_packets_;
+  SteadyHeap<PacketBase*,
+             std::function<bool(const PacketBase*, const PacketBase*)>>
+      queued_packets_;
 
   const char* name_;          ///< See GetName().
   int capacity_;              ///< See GetCapacity().

--- a/src/SchedulerImpl.cpp
+++ b/src/SchedulerImpl.cpp
@@ -129,8 +129,8 @@ void SchedulerImpl::JobsDropped(ChannelImpl* channel) {
   }
 }
 
-bool SchedulerImpl::ChannelOrdering::operator()(ChannelImpl* a,
-                                                ChannelImpl* b) {
+bool SchedulerImpl::ChannelOrdering::operator()(const ChannelImpl* a,
+                                                const ChannelImpl* b) {
   return a->PeekNext() > b->PeekNext();
 }
 

--- a/src/SchedulerImpl.cpp
+++ b/src/SchedulerImpl.cpp
@@ -9,7 +9,10 @@
 namespace pipert {
 
 SchedulerImpl::SchedulerImpl(int workers_number)
-    : keep_running_(false), running_(false), workers_number_(workers_number) {
+    : state_queue_(StateOrdering(&state2channel_queues_)),
+      keep_running_(false),
+      running_(false),
+      workers_number_(workers_number) {
   assert(workers_number > 0);
   workers_.reserve(workers_number);
 }
@@ -75,22 +78,16 @@ void SchedulerImpl::JobsArrived(ChannelImpl* channel) {
   // No locking as it is called from ChannelImpl or here
   void* state = channel->GetState();
   auto& chq = state2channel_queues_[state];
-  assert(std::count(chq.heap.begin(), chq.heap.end(), channel) == 0);
+  assert(chq.heap.count(channel) == 0);
   Timer::Time earliest =
       chq.heap.empty() ? Timer::kMaxTime : chq.heap.front()->PeekNext();
-  chq.heap.push_back(channel);
-  std::push_heap(chq.heap.begin(), chq.heap.end(), ChannelOrdering());
+  chq.heap.push_heap(channel);
   if (chq.enabled && chq.heap.front()->PeekNext() < earliest) {
     if (earliest != Timer::kMaxTime) {
-      MoveToTopInHeap(state_queue_, state);
-      std::pop_heap(state_queue_.begin(), state_queue_.end(),
-                    StateOrdering(&state2channel_queues_));
-      state_queue_.pop_back();
+      state_queue_.force_pop_heap(state);
     }
-    assert(std::count(state_queue_.begin(), state_queue_.end(), state) == 0);
-    state_queue_.push_back(state);
-    std::push_heap(state_queue_.begin(), state_queue_.end(),
-                   StateOrdering(&state2channel_queues_));
+    assert(state_queue_.count(state) == 0);
+    state_queue_.push_heap(state);
     global_covar_.notify_one();
   }
 }
@@ -100,23 +97,15 @@ void SchedulerImpl::JobsUpdated(ChannelImpl* channel, bool was_push) {
   void* state = channel->GetState();
   auto& chq = state2channel_queues_[state];
   assert(!chq.heap.empty());
-  assert(std::count(chq.heap.begin(), chq.heap.end(), channel) == 1);
+  assert(chq.heap.count(channel) == 1);
   bool was_top = (chq.heap.front() == channel);
   Timer::Time earliest = chq.heap.front()->PeekNext();
-  MoveToTopInHeap(chq.heap, channel);
-  std::pop_heap(chq.heap.begin(), chq.heap.end(), ChannelOrdering());
-  chq.heap.pop_back();
-  chq.heap.push_back(channel);
-  std::push_heap(chq.heap.begin(), chq.heap.end(), ChannelOrdering());
+  chq.heap.force_pop_heap(channel);
+  chq.heap.push_heap(channel);
   if (chq.enabled && (chq.heap.front()->PeekNext() != earliest || was_top)) {
-    MoveToTopInHeap(state_queue_, state);
-    std::pop_heap(state_queue_.begin(), state_queue_.end(),
-                  StateOrdering(&state2channel_queues_));
-    state_queue_.pop_back();
-    assert(std::count(state_queue_.begin(), state_queue_.end(), state) == 0);
-    state_queue_.push_back(state);
-    std::push_heap(state_queue_.begin(), state_queue_.end(),
-                   StateOrdering(&state2channel_queues_));
+    state_queue_.force_pop_heap(state);
+    assert(state_queue_.count(state) == 0);
+    state_queue_.push_heap(state);
     if (was_push) {
       global_covar_.notify_one();
     }
@@ -128,21 +117,14 @@ void SchedulerImpl::JobsDropped(ChannelImpl* channel) {
   void* state = channel->GetState();
   auto& chq = state2channel_queues_[state];
   assert(!chq.heap.empty());
-  assert(std::count(chq.heap.begin(), chq.heap.end(), channel) == 1);
+  assert(chq.heap.count(channel) == 1);
   bool was_top = (chq.heap.front() == channel);
-  MoveToTopInHeap(chq.heap, channel);
-  std::pop_heap(chq.heap.begin(), chq.heap.end(), ChannelOrdering());
-  chq.heap.pop_back();
+  chq.heap.force_pop_heap(channel);
   if (chq.enabled && was_top) {
-    MoveToTopInHeap(state_queue_, state);
-    std::pop_heap(state_queue_.begin(), state_queue_.end(),
-                  StateOrdering(&state2channel_queues_));
-    state_queue_.pop_back();
-    assert(std::count(state_queue_.begin(), state_queue_.end(), state) == 0);
+    state_queue_.force_pop_heap(state);
+    assert(state_queue_.count(state) == 0);
     if (!chq.heap.empty()) {
-      state_queue_.push_back(state);
-      std::push_heap(state_queue_.begin(), state_queue_.end(),
-                     StateOrdering(&state2channel_queues_));
+      state_queue_.push_heap(state);
     }
   }
 }
@@ -188,9 +170,7 @@ void SchedulerImpl::RunTasks() {
         if (state != nullptr) {
           // set stateful channels for this state to disabled
           chq.enabled = false;
-          std::pop_heap(state_queue_.begin(), state_queue_.end(),
-                        StateOrdering(&state2channel_queues_));
-          state_queue_.pop_back();
+          state_queue_.pop_heap();
         }
         packet = channel->PopNext();
         assert(packet);
@@ -202,16 +182,13 @@ void SchedulerImpl::RunTasks() {
       if (state != nullptr) {
         // set stateful channels for this state to enabled again
         std::lock_guard<AdaptiveSpinLock> lock(global_mutex_);
-        assert(std::count(state_queue_.begin(), state_queue_.end(), state) ==
-               0);
+        assert(state_queue_.count(state) == 0);
         assert(state2channel_queues_.count(state) == 1);
         auto& chq = state2channel_queues_[state];
         assert(!chq.enabled);
         chq.enabled = true;
         if (!chq.heap.empty()) {
-          state_queue_.push_back(state);
-          std::push_heap(state_queue_.begin(), state_queue_.end(),
-                         StateOrdering(&state2channel_queues_));
+          state_queue_.push_heap(state);
           // we do not need global_covar_.notify_one() here as this thread goes
           // on by servicing this state
         }

--- a/src/SchedulerImpl.h
+++ b/src/SchedulerImpl.h
@@ -84,11 +84,12 @@ class SchedulerImpl {
   /// of a stateful node has a thread currently executing a job.
   /// Until the job is done, no other threads are allowed to enter.
   struct EnabledChannelHeap {
-    EnabledChannelHeap()
-        : enabled(true), heap(ChannelOrdering()) {}
+    EnabledChannelHeap() : enabled(true), heap(ChannelOrdering()) {}
     bool enabled;
     /// A heap is used as it can work as an in-place queue.
-    SteadyHeap<ChannelImpl*, std::function<bool(ChannelImpl*, ChannelImpl*)>> heap;
+    SteadyHeap<ChannelImpl*,
+               std::function<bool(const ChannelImpl*, const ChannelImpl*)>>
+        heap;
   };
 
   /// Monitor object to channel heap mapping.
@@ -96,7 +97,7 @@ class SchedulerImpl {
 
   /// Ordering of channels based on earliest timestamp for ChannelHeap.
   struct ChannelOrdering {
-    bool operator()(ChannelImpl* a, ChannelImpl* b);
+    bool operator()(const ChannelImpl* a, const ChannelImpl* b);
   };
 
   /// Ordering of monitor objects based on the earliest timestamp for StateHeap.
@@ -114,7 +115,7 @@ class SchedulerImpl {
   AdaptiveSpinLock global_mutex_;             ///< See GetMutex().
   std::condition_variable_any global_covar_;  ///< CV for waking up threads.
   /// Queue for states in timestamp order as a heap of monitor objects
-  SteadyHeap<void*, std::function<bool(void*, void*)>> state_queue_; 
+  SteadyHeap<void*, std::function<bool(void*, void*)>> state_queue_;
   State2ChannelHeap state2channel_queues_;  ///< State to channel mapping.
   std::vector<std::thread> workers_;        ///< Worker thread pool.
   std::atomic_bool keep_running_;           ///< Tells threads to run or not.

--- a/src/SteadyHeap.h
+++ b/src/SteadyHeap.h
@@ -26,54 +26,51 @@ namespace pipert {
 /// yields a max heap, and greater-than yields a min heap.
 template <typename T, typename StrictOrdering>
 class SteadyHeap {
- private:
-  /// The fixed-size space in memory that the heap is realized in.
-  std::vector<T> _heap;
-  /// The strict ordering that is used to compare elements inside the heap.
-  StrictOrdering _ordering;
-
  public:
   /// Construct a SteadyHeap with a strict ordering.
   ///
   /// \param ordering See the template parameter StrictOrdering for more
   /// information. Probably best implemented as a std::function wrapper.
-  SteadyHeap(StrictOrdering ordering) : _ordering(ordering) {}
+  SteadyHeap(StrictOrdering ordering) : ordering_(ordering) {}
 
   /// \return Whether the container is empty.
-  bool empty() const { return _heap.empty(); }
+  bool empty() const { return heap_.empty(); }
 
   /// \return The number of elements in the container.
-  std::size_t size() const { return _heap.size(); }
+  std::size_t size() const { return heap_.size(); }
 
   /// \return The reserved size of the container.
-  std::size_t capacity() const { return _heap.capacity(); }
-
-  /// \return An unmodifiable reference to the element at the top of the heap.
-  const T& front() const { return _heap.front(); }
+  std::size_t capacity() const { return heap_.capacity(); }
 
   /// Reserves the space in memory the heap is allowed to occupy at its fullest.
-  void reserve(std::size_t n) { _heap.reserve(n); }
+  void reserve(std::size_t n) { heap_.reserve(n); }
 
-  /// Finds an element in the heap using `std::find`.
-  typename std::vector<T>::iterator find(const T& value) {
-    return std::find(_heap.begin(), _heap.end(), value);
+  /// \return A constant iterator to the beginning of the collection
+  typename std::vector<T>::const_iterator begin() const {
+    return heap_.begin();
   }
+
+  /// \return A constant iterator to the beginning of the collection
+  typename std::vector<T>::const_iterator end() const { return heap_.end(); }
+
+  /// \return An unmodifiable reference to the element at the top of the heap.
+  const T& front() const { return heap_.front(); }
 
   /// Counts the number of occurrences of an element using `std::count`.
   std::ptrdiff_t count(const T& value) const {
-    return std::count(_heap.begin(), _heap.end(), value);
+    return std::count(heap_.begin(), heap_.end(), value);
   }
 
   /// Push an element onto the heap.
-  void push_heap(T& value) {
-    _heap.push_back(value);
-    std::push_heap(_heap.begin(), _heap.end(), _ordering);
+  void push_heap(const T& value) {
+    heap_.push_back(value);
+    std::push_heap(heap_.begin(), heap_.end(), ordering_);
   }
 
   /// Pop the element at the top of the heap.
   void pop_heap() {
-    std::pop_heap(_heap.begin(), _heap.end(), _ordering);
-    _heap.pop_back();
+    std::pop_heap(heap_.begin(), heap_.end(), ordering_);
+    heap_.pop_back();
   }
 
   /// A special method that forces an element onto the top of the heap, and then
@@ -90,16 +87,22 @@ class SteadyHeap {
   /// force-popped from the heap because it was modified, see
   /// `SteadyHeap::force_pop_heap(T)`.
   void force_to_top(const T& value) {
-    typename std::vector<T>::iterator it = find(value);
-    assert(it != _heap.end());
-    int i = &(*it) - &_heap[0];
+    typename std::vector<T>::iterator it =
+        std::find(heap_.begin(), heap_.end(), value);
+    assert(it != heap_.end());
+    int i = &(*it) - &heap_[0];
     while (i > 0) {
       int j = (i - 1) / 2;
       assert(j < i);
-      std::swap(_heap[i], _heap[j]);
+      std::swap(heap_[i], heap_[j]);
       i = j;
     }
   }
+
+  /// The fixed-size space in memory that the heap is realized in.
+  std::vector<T> heap_;
+  /// The strict ordering that is used to compare elements inside the heap.
+  StrictOrdering ordering_;
 };
 
 }  // namespace pipert

--- a/src/SteadyHeap.h
+++ b/src/SteadyHeap.h
@@ -1,0 +1,107 @@
+#ifndef _STEADY_HEAP_H_
+#define _STEADY_HEAP_H_
+
+#include <algorithm>
+#include <cassert>
+#include <vector>
+
+namespace pipert {
+
+/// A SteadyHeap wraps the functionality of a heap that can be restrained to
+/// occupy a fix-sized space in memory. It does this by encapsulating a vector
+/// and by providing only the interface to reserve the maximum amount of memory
+/// this heap is allowed to consume, as well as providing methods for handling
+/// its contents as a heap. This container wrapper is specially adapted to our
+/// needs, and contains only the functions the library uses. It does not give a
+/// complete interface for a generic heap, and the implementation is expected to
+/// be extended when new requirements arise in the library.
+///
+/// \tparam T The type of data the heap will contain as its elements.
+/// \tparam StrictOrdering The type of the comparison operation that will be
+/// used to determine the positioning of elements in the heap. It should satisfy
+/// the requirements of _Compare_, meaning that the return value of the
+/// comparison function, when contextually converted to `bool`, should yield
+/// `true` if its first argument appears before the second in the strict weak
+/// ordering induced by the type of its parameters. Comparison using less-than
+/// yields a max heap, and greater-than yields a min heap.
+template <typename T, typename StrictOrdering>
+class SteadyHeap {
+ private:
+  /// The fixed-size space in memory that the heap is realized in.
+  std::vector<T> _heap;
+  /// The strict ordering that is used to compare elements inside the heap.
+  StrictOrdering _ordering;
+
+ public:
+  /// Construct a SteadyHeap with a strict ordering.
+  ///
+  /// \param ordering See the template parameter StrictOrdering for more
+  /// information. Probably best implemented as a std::function wrapper.
+  SteadyHeap(StrictOrdering ordering) : _ordering(ordering) {}
+
+  /// \return Whether the container is empty.
+  bool empty() const { return _heap.empty(); }
+
+  /// \return The number of elements in the container.
+  std::size_t size() const { return _heap.size(); }
+
+  /// \return The reserved size of the container.
+  std::size_t capacity() const { return _heap.capacity(); }
+
+  /// \return An unmodifiable reference to the element at the top of the heap.
+  const T& front() const { return _heap.front(); }
+
+  /// Reserves the space in memory the heap is allowed to occupy at its fullest.
+  void reserve(std::size_t n) { _heap.reserve(n); }
+
+  /// Finds an element in the heap using `std::find`.
+  typename std::vector<T>::iterator find(const T& value) {
+    return std::find(_heap.begin(), _heap.end(), value);
+  }
+
+  /// Counts the number of occurrences of an element using `std::count`.
+  std::ptrdiff_t count(const T& value) const {
+    return std::count(_heap.begin(), _heap.end(), value);
+  }
+
+  /// Push an element onto the heap.
+  void push_heap(T& value) {
+    _heap.push_back(value);
+    std::push_heap(_heap.begin(), _heap.end(), _ordering);
+  }
+
+  /// Pop the element at the top of the heap.
+  void pop_heap() {
+    std::pop_heap(_heap.begin(), _heap.end(), _ordering);
+    _heap.pop_back();
+  }
+
+  /// A special method that forces an element onto the top of the heap, and then
+  /// pops it from there. This is useful when a modified element has to be
+  /// removed from (and later reinserted into) the heap, because the
+  /// modification could have affected its position inside the heap.
+  void force_pop_heap(const T& value) {
+    force_to_top(value);
+    pop_heap();
+  }
+
+ private:
+  /// Forces an element to the top of the heap. Used when an element has to be
+  /// force-popped from the heap because it was modified, see
+  /// `SteadyHeap::force_pop_heap(T)`.
+  void force_to_top(const T& value) {
+    typename std::vector<T>::iterator it = find(value);
+    assert(it != _heap.end());
+    int i = &(*it) - &_heap[0];
+    while (i > 0) {
+      int j = (i - 1) / 2;
+      assert(j < i);
+      std::swap(_heap[i], _heap[j]);
+      i = j;
+    }
+  }
+};
+
+}  // namespace pipert
+
+#endif  //_STEADY_HEAP_H_

--- a/test/SteadyHeapTest.cpp
+++ b/test/SteadyHeapTest.cpp
@@ -1,0 +1,77 @@
+#include "SteadyHeap.h"
+#include "gtest/gtest.h"
+
+#include <algorithm>
+#include <functional>
+#include <vector>
+
+TEST(SteadyHeap, SteadyHeapReserveTest) {
+  pipert::SteadyHeap<int, std::function<bool(const int&, const int&)>> sh{
+      std::less<int>()};
+  EXPECT_TRUE(sh.empty());
+  EXPECT_EQ(sh.capacity(), 0);
+  EXPECT_EQ(sh.size(), 0);
+  sh.reserve(1);
+  EXPECT_TRUE(sh.empty());
+  EXPECT_EQ(sh.capacity(), 1);
+  EXPECT_EQ(sh.size(), 0);
+  sh.reserve(0);
+  EXPECT_TRUE(sh.empty());
+  EXPECT_EQ(sh.capacity(), 1);
+  EXPECT_EQ(sh.size(), 0);
+}
+
+TEST(SteadyHeap, SteadyHeapPushPopTest) {
+  pipert::SteadyHeap<int, std::function<bool(const int&, const int&)>> sh{
+      std::less<int>()};
+  const std::vector<int> v{3, 2, 4, 8, 6, 7};
+  sh.reserve(v.size());
+  EXPECT_EQ(sh.size(), 0);
+  for (unsigned long i = 0; i < v.size(); ++i) {
+    EXPECT_EQ(sh.size(), i);
+    sh.push_heap(v[i]);
+  }
+  EXPECT_EQ(sh.size(), v.size());
+  for (unsigned long i = v.size(); i > 0; --i) {
+    EXPECT_EQ(sh.size(), i);
+    sh.pop_heap();
+  }
+  EXPECT_EQ(sh.size(), 0);
+}
+
+TEST(SteadyHeap, SteadyHeapOrderingTest) {
+  pipert::SteadyHeap<int, std::function<bool(const int&, const int&)>> sh{
+      std::less<int>()};
+  const std::vector<int> v{3, 2, 4, 8, 6, 7};
+  std::vector<int> descend{v};
+  std::sort(descend.begin(), descend.end(), std::greater<int>());
+  sh.reserve(v.size());
+  for (unsigned long i = 0; i < v.size(); ++i) {
+    sh.push_heap(v[i]);
+    EXPECT_EQ(sh.front(), *std::max_element(v.begin(), v.begin() + i + 1));
+  }
+  for (unsigned long i = 0; i < v.size(); ++i) {
+    EXPECT_EQ(sh.front(), descend[i]);
+    sh.pop_heap();
+  }
+}
+
+TEST(SteadyHeap, SteadyHeapForcePopTest) {
+  pipert::SteadyHeap<int, std::function<bool(const int&, const int&)>> sh{
+      std::less<int>()};
+  const std::vector<int> v{3, 2, 4, 8, 6, 7};
+  for (unsigned long i = 0; i < v.size(); ++i) {
+    sh.push_heap(v[i]);
+  }
+  const int min = *std::min_element(sh.begin(), sh.end());
+  const int max = *std::max_element(sh.begin(), sh.end());
+  EXPECT_NE(std::min_element(sh.begin(), sh.end()),
+            std::max_element(sh.begin(), sh.end()));
+  EXPECT_EQ(sh.size(), v.size());
+  EXPECT_NE(std::find(sh.begin(), sh.end(), min), sh.end());
+  EXPECT_EQ(sh.front(), max);
+  sh.force_pop_heap(min);
+  EXPECT_EQ(sh.size(), v.size() - 1);
+  EXPECT_EQ(std::find(sh.begin(), sh.end(), min), sh.end());
+  EXPECT_EQ(sh.front(), max);
+}


### PR DESCRIPTION
Created a drop-in replacement to the heap-in-fixed-size-vector solutions used previously in ChannelImpl and SchedulerImpl. A lot of regular usage patterns emerged in those use cases, so calls to SteadyHeap could minimize and simplify a lot of code.